### PR TITLE
Fix possible crash caused by hard-dependency on django-auditlog.

### DIFF
--- a/resilient_logger/sources/__init__.py
+++ b/resilient_logger/sources/__init__.py
@@ -1,11 +1,18 @@
+import typing
+
 from resilient_logger.utils import unavailable_class
 
 from .abstract_log_source import AbstractLogSource as AbstractLogSource
 from .resilient_log_source import ResilientLogSource as ResilientLogSource
 
-try:
+if typing.TYPE_CHECKING:
     from .django_audit_log_source import DjangoAuditLogSource as DjangoAuditLogSource
-except ImportError:
-    DjangoAuditLogSource = unavailable_class(
-        "DjangoAuditLogSource", ["django-auditlog"]
-    )
+else:
+    try:
+        from .django_audit_log_source import (
+            DjangoAuditLogSource as DjangoAuditLogSource,
+        )
+    except ImportError:
+        DjangoAuditLogSource = unavailable_class(
+            "DjangoAuditLogSource", ["django-auditlog"]
+        )

--- a/resilient_logger/sources/__init__.py
+++ b/resilient_logger/sources/__init__.py
@@ -6,4 +6,6 @@ from .resilient_log_source import ResilientLogSource as ResilientLogSource
 try:
     from .django_audit_log_source import DjangoAuditLogSource as DjangoAuditLogSource
 except ImportError:
-    DjangoAuditLogSource = unavailable_class("DjangoAuditLogSource", "django-auditlog")
+    DjangoAuditLogSource = unavailable_class(
+        "DjangoAuditLogSource", ["django-auditlog"]
+    )

--- a/resilient_logger/sources/__init__.py
+++ b/resilient_logger/sources/__init__.py
@@ -1,3 +1,9 @@
+from resilient_logger.utils import unavailable_class
+
 from .abstract_log_source import AbstractLogSource as AbstractLogSource
-from .django_audit_log_source import DjangoAuditLogSource as DjangoAuditLogSource
 from .resilient_log_source import ResilientLogSource as ResilientLogSource
+
+try:
+    from .django_audit_log_source import DjangoAuditLogSource as DjangoAuditLogSource
+except ImportError:
+    DjangoAuditLogSource = unavailable_class("DjangoAuditLogSource", "django-auditlog")

--- a/resilient_logger/sources/django_audit_log_source.py
+++ b/resilient_logger/sources/django_audit_log_source.py
@@ -24,8 +24,10 @@ class DjangoAuditLogSource(AbstractLogSource):
         actor: Optional[AbstractUser] = self.log.actor
         # Looks up the action tuple [int, str] and uses name of it
         action = LogEntry.Action.choices[self.log.action][1]
+        additional_data = self.log.additional_data or {}
+
         extra = {
-            **self.log.additional_data,
+            **additional_data,
             "changes": self.log.changes,
         }
 

--- a/resilient_logger/utils.py
+++ b/resilient_logger/utils.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import logging
+from collections.abc import Sequence
 from functools import cache
 from importlib import import_module
 from typing import Any, Optional, TypedDict, TypeVar
@@ -124,7 +125,7 @@ def content_hash(contents: dict[str, Any]) -> str:
     return hashlib.sha256(json_repr.encode()).hexdigest()
 
 
-def unavailable_class(name: str, dependency: str):
+def unavailable_class(name: str, dependencies: Sequence[str]):
     """
     Creates a placeholder class that raises ImportError on instantiation.
 
@@ -132,15 +133,14 @@ def unavailable_class(name: str, dependency: str):
         name (str): Name of the class (for nicer repr).
         dependency (str): The missing dependency to mention in the error.
     """
+    deps = ", ".join(f"'{d}'" for d in dependencies)
 
     class _UnavailableClass:
         def __init__(self, *args, **kwargs):
-            raise ImportError(
-                f"{name} requires the optional dependency '{dependency}'. "
-            )
+            raise ImportError(f"{name} requires the optional dependencies: {deps}. ")
 
         def __repr__(self):
-            return f"<Unavailable class {name} (missing dependency '{dependency}')>"
+            return f"<Unavailable class {name} (missing dependencies: {deps})>"
 
     _UnavailableClass.__name__ = name
     return _UnavailableClass

--- a/resilient_logger/utils.py
+++ b/resilient_logger/utils.py
@@ -122,3 +122,25 @@ def get_resilient_logger_config() -> ResilientLoggerConfig:
 def content_hash(contents: dict[str, Any]) -> str:
     json_repr = json.dumps(contents, sort_keys=True, cls=DjangoJSONEncoder)
     return hashlib.sha256(json_repr.encode()).hexdigest()
+
+
+def unavailable_class(name: str, dependency: str):
+    """
+    Creates a placeholder class that raises ImportError on instantiation.
+
+    Parameters:
+        name (str): Name of the class (for nicer repr).
+        dependency (str): The missing dependency to mention in the error.
+    """
+
+    class _UnavailableClass:
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                f"{name} requires the optional dependency '{dependency}'. "
+            )
+
+        def __repr__(self):
+            return f"<Unavailable class {name} (missing dependency '{dependency}')>"
+
+    _UnavailableClass.__name__ = name
+    return _UnavailableClass

--- a/tests/test_django_audit_log_source.py
+++ b/tests/test_django_audit_log_source.py
@@ -1,3 +1,6 @@
+import importlib
+from unittest.mock import patch
+
 import pytest
 from auditlog.models import LogEntry
 from django.test import override_settings
@@ -83,3 +86,15 @@ def test_clear_sent_entries():
 
     cleaned_ids = DjangoAuditLogSource.clear_sent_entries(0)
     assert len(cleaned_ids) == 0
+
+
+def test_optional_django_audit_log():
+    with patch.dict(
+        "sys.modules", {"resilient_logger.sources.django_audit_log_source": None}
+    ):
+        import resilient_logger.sources as sources
+
+        importlib.reload(sources)
+
+        with pytest.raises(ImportError):
+            sources.DjangoAuditLogSource()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 from django.test import override_settings
 
-from resilient_logger.utils import get_resilient_logger_config
+from resilient_logger.utils import get_resilient_logger_config, unavailable_class
 from tests.testdata.testconfig import (
     INVALID_CONFIG_MISSING_SOURCES,
     INVALID_CONFIG_MISSING_TARGETS,
@@ -40,3 +40,11 @@ def test_invalid_config_missing_targets():
 def test_invalid_config_missing_sources():
     with pytest.raises(RuntimeError):
         get_resilient_logger_config()
+
+
+def test_unavailable_class():
+    with pytest.raises(ImportError) as ex:
+        placeholder_class = unavailable_class("ClassName", ["library-name"])
+        placeholder_class()
+
+    assert ex.match("ClassName requires the optional dependencies: 'library-name'.")


### PR DESCRIPTION
django-auditlog is meant to be optional dependency, but the code would crash since DjangoAuditLogSource is re-exported from `sources/__init__.py` file. Make sure that missing package and thus failed import does not crash the whole app using this library.