### PR TITLE
Tooling updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,12 +160,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+# IDE files
+.idea/
+.vscode/
 
 # PyPI configuration file
 .pypirc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: "1.29.1"
     hooks:
       - id: django-upgrade
-        args: [--target-version, "4.2"]
+        args: [--target-version, "5.2"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.3
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,8 @@ keywords=[
 classifiers=[
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
@@ -34,7 +33,7 @@ classifiers=[
 ]
 license = "MIT"
 license-files = ["LICENSE"]
-dependencies = ["django>=4.2", "elasticsearch8"]
+dependencies = ["django>=5.2", "elasticsearch8"]
 
 [project.optional-dependencies]
 test = [
@@ -84,16 +83,12 @@ parallel = false
 randomize = true
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.10", "3.11", "3.12"]
-django = ["4.2", "5.1", "5.2"]
-
-[[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.13"]
-django = ["5.1", "5.2"]
-
-[[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.14"]
+python = ["3.10", "3.11"]
 django = ["5.2"]
+
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.12", "3.13", "3.14"]
+django = ["5.2", "6.0"]
 
 [tool.hatch.envs.hatch-test.overrides]
 matrix.django.dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,11 @@ lint = [
 ]
 manage = "tests/manage.py {args}"
 
+[tool.hatch.envs.hatch-uv]
+dependencies = [
+  "uv>=0.11.1",
+]
+
 [tool.hatch.envs.hatch-test]
 default-args = ["tests"]
 features = ["all"]
@@ -142,3 +147,6 @@ plugins = ["mypy_django_plugin.main"]
 
 [tool.django-stubs]
 django_settings_module = "tests.settings"
+
+[tool.uv]
+exclude-newer = "14 days"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,8 @@ dependencies = ["django>=5.2", "elasticsearch8"]
 test = [
     "pytest",
     "pytest-django",
-    "coverage-enable-subprocess",
     "coverage[toml]",
     "pytest-randomly",
-    "pytest-rerunfailures",
-    "pytest-xdist[psutil]",
 ]
 auditlog = ["django-auditlog"]
 all = ["django-resilient-logger[auditlog]", "django-resilient-logger[test]"]


### PR DESCRIPTION
Updates:
- Drop support for django 4.2, 5.1, add 6.0 support
- Drop unused/redundant dependencies
- Limit packages to only 2 weeks old or older
- Add IDE files to .gitignore

Refs: [KEH-282](https://helsinkisolutionoffice.atlassian.net/browse/KEH-282)

[KEH-282]: https://helsinkisolutionoffice.atlassian.net/browse/KEH-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ