### PR TITLE
feat: add too big payload handling

### DIFF
--- a/resilient_logger/targets/elasticsearch_log_target.py
+++ b/resilient_logger/targets/elasticsearch_log_target.py
@@ -1,7 +1,7 @@
 import logging
 from urllib.parse import urlparse
 
-from elasticsearch8 import ConflictError, Elasticsearch
+from elasticsearch8 import ApiError, ConflictError, Elasticsearch
 
 from resilient_logger.sources.abstract_log_source_entry import AbstractLogSourceEntry
 from resilient_logger.targets import AbstractLogTarget
@@ -41,6 +41,7 @@ class ElasticsearchLogTarget(AbstractLogTarget):
         es_host: str | None = None,
         es_port: int | None = 9200,
         es_scheme: str | None = "https",
+        es_compress: bool = False,
         required: bool = True,
     ) -> None:
         if not es_url:
@@ -60,6 +61,7 @@ class ElasticsearchLogTarget(AbstractLogTarget):
         self._client = Elasticsearch(
             [{"host": host, "port": port, "scheme": scheme}],
             basic_auth=(es_username, es_password),
+            http_compress=es_compress,
         )
         self._required = required
 
@@ -96,10 +98,27 @@ class ElasticsearchLogTarget(AbstractLogTarget):
             )
 
             return True
-        except Exception:
-            """
-            Unknown exception, log it and keep going to avoid transaction rollbacks.
-            """
-            logger.exception(f"Entry with key {hash} failed.")
+        except ApiError as e:
+            if e.status_code == 413:
+                """
+                Payload size is too big, there is not much we can do.
+                Log the details for developer to find the row and handle
+                it manually.
+                """
+                logger.error(
+                    f"Payload is too big for {hash}. Source PK: {entry.get_id()}"
+                )
+                return False
 
+            return self._handle_exception(hash, entry)
+        except Exception:
+            return self._handle_exception(hash, entry)
+
+        return False
+
+    def _handle_exception(self, hash: str, entry: AbstractLogSourceEntry) -> bool:
+        """
+        Unknown exception, log it and keep going to avoid transaction rollbacks.
+        """
+        logger.exception(f"Entry with key {hash} failed. Source PK: {entry.get_id()}")
         return False

--- a/tests/test_elasticsearch_log_target.py
+++ b/tests/test_elasticsearch_log_target.py
@@ -1,6 +1,9 @@
+import logging
 from base64 import b64encode
+from unittest.mock import MagicMock, patch
 
 import pytest
+from elasticsearch8 import ApiError
 
 from resilient_logger.targets import ElasticsearchLogTarget
 
@@ -98,3 +101,120 @@ def test_create_parts_without_scheme():
     assert node.port == port
     assert target._index == index
     assert authorization == expected_authorization
+
+
+@patch("resilient_logger.targets.elasticsearch_log_target.Elasticsearch")
+def test_http_compression_is_enabled(mock_elasticsearch):
+    """
+    Ensure that http_compress=True is explicitly passed to the Elasticsearch client
+    when es_compress is set to True.
+    """
+    mock_client_instance = MagicMock()
+    mock_elasticsearch.return_value = mock_client_instance
+
+    ElasticsearchLogTarget(
+        es_username="test_user",
+        es_password="test_password",
+        es_index="test_index",
+        es_host="localhost",
+        es_compress=True,
+    )
+
+    mock_elasticsearch.assert_called_once()
+    _, kwargs = mock_elasticsearch.call_args
+
+    assert "http_compress" in kwargs, "http_compress keyword argument missing"
+    assert kwargs["http_compress"] is True, "http_compress should be set to True"
+
+
+@patch("resilient_logger.targets.elasticsearch_log_target.Elasticsearch")
+def test_http_compression_is_disabled_by_default(mock_elasticsearch):
+    """
+    Ensure that http_compress defaults to False when es_compress is omitted.
+    """
+    ElasticsearchLogTarget(
+        es_username="test_user",
+        es_password="test_password",
+        es_index="test_index",
+        es_host="localhost",
+    )
+
+    # Assert
+    _, kwargs = mock_elasticsearch.call_args
+    assert kwargs.get("http_compress") is False, "http_compress should default to False"
+
+
+@patch("resilient_logger.targets.elasticsearch_log_target.Elasticsearch")
+def test_es_exception(mock_elasticsearch, caplog):
+    mock_client_instance = MagicMock()
+    mock_elasticsearch.return_value = mock_client_instance
+
+    mock_meta = MagicMock()
+    mock_meta.status = 500
+    api_error = ApiError(
+        message="Blabla",
+        meta=mock_meta,
+        body={"error": "Blabla"},
+    )
+    mock_client_instance.index.side_effect = api_error
+
+    target = ElasticsearchLogTarget(
+        es_username="test_user",
+        es_password="test_password",
+        es_index="test_index",
+        es_host="localhost",
+    )
+
+    mock_entry = MagicMock()
+    mock_entry.get_document.return_value = {"message": "exception"}
+    mock_entry.get_id.return_value = "source_pk_123"
+
+    with caplog.at_level(
+        logging.ERROR, logger="resilient_logger.targets.elasticsearch_log_target"
+    ):
+        target.submit(mock_entry)
+
+    assert len(caplog.records) == 1, "Expected exactly one error log record"
+    log_record = caplog.records[0]
+
+    assert log_record.levelname == "ERROR"
+    assert log_record.message.startswith("Entry with key ")
+    assert log_record.message.endswith("failed. Source PK: source_pk_123")
+
+
+@patch("resilient_logger.targets.elasticsearch_log_target.Elasticsearch")
+def test_413_payload_too_big(mock_elasticsearch, caplog):
+    mock_client_instance = MagicMock()
+    mock_elasticsearch.return_value = mock_client_instance
+
+    mock_meta = MagicMock()
+    mock_meta.status = 413
+    api_error = ApiError(
+        message="Request Entity Too Large",
+        meta=mock_meta,
+        body={"error": "Payload too big"},
+    )
+    mock_client_instance.index.side_effect = api_error
+
+    target = ElasticsearchLogTarget(
+        es_username="test_user",
+        es_password="test_password",
+        es_index="test_index",
+        es_host="localhost",
+    )
+
+    mock_entry = MagicMock()
+    mock_entry.get_document.return_value = {"message": "massive_log_payload"}
+    mock_entry.get_id.return_value = "source_pk_123"
+
+    with caplog.at_level(
+        logging.ERROR, logger="resilient_logger.targets.elasticsearch_log_target"
+    ):
+        target.submit(mock_entry)
+
+    assert len(caplog.records) == 1, "Expected exactly one error log record"
+    log_record = caplog.records[0]
+
+    assert log_record.levelname == "ERROR"
+    assert log_record.message.startswith("Payload is too big for ")
+    assert log_record.message.endswith("Source PK: source_pk_123")


### PR DESCRIPTION
Kaavapino tries to push geodata into audit logs that fails with payload too big error. 
Try to catch it and handle more gracefully.

Also adds new boolean flag into ElasticsearchLogTarget called `es_compress`, that tries to activate HTTP compression for ES client.